### PR TITLE
Moves python API server to a WSGI environment

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -12,4 +12,4 @@ RUN pip install -r /requirements.txt
 
 COPY api /data
 
-CMD ["python", "main.py"]
+CMD ["gunicorn", "main:app", "-b", "0.0.0.0:5000", "-w", "2"]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ google-api-python-client==1.7.10
 google-auth==1.6.3
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.4.0
+gunicorn==19.9.0
 httplib2==0.13.1
 idna==2.8
 itsdangerous==1.1.0


### PR DESCRIPTION
# What is the purpose of this PR?

To move the flask API to a `gunicorn` WSGI environment inside the docker runtime.

# Why is this necessary?

We have a problem with the API crashing. It's probably due to an unhandled error, and this causes the API runtime to crash without actually terminating the container it is being run on.

We could solve this in various ways:
- Find a way to actually completely terminate the container on a crash, so that the orchestrator would just deploy another container
- Have a "disaster recovery" measure on each container, so that when a runtime crashes, it'd just start another runtime on the same container.

The easiest and recommended solution on that problem is the second option: to _actually move it to a production environment_ inside the container.

# How can this be manually tested?

Build with `docker build . -t lh-api -f Dockerfile-web` and run with `docker run -it -p 5000:5000 lh-api`. After that, `curl localhost:5000/hacks | python3 -m json.tool` should return a correct response.