### PR TITLE
Adds a temporary history symbol for mobile

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -18,7 +18,8 @@
         <p>LIGHTNING HACKS</p>
     </a>
     <span class="header--menu">
-        <a href="/log"><p>Histórico</p></a>
+        <a class="header--desktop-history" href="/log"><p>Histórico</p></a>
+        <a class="header--mobile-history" href="/log"><p>H</p></a>
     </span>
     <span class="header--line"></span>
 </header>

--- a/src/_sass/lh.scss
+++ b/src/_sass/lh.scss
@@ -72,6 +72,10 @@ body {
   padding-right: 4em;
 }
 
+.header--mobile-history {
+  display: none; 
+}
+
 .header--logo {
   height: 2.2em;
   width: 1.3em;
@@ -161,7 +165,16 @@ body {
 }
 
 @media (max-width: 800px) {
-  .header--menu {
+  .header--desktop-history {
     display: none;
+  }
+
+  .header--mobile-history {
+    display: inherit;
+    font-weight: bold;
+  }
+
+  .header--menu {
+    padding-right: 1em;
   }
 }


### PR DESCRIPTION
The symbol is an "H" like this:

![image](https://user-images.githubusercontent.com/37511135/68428906-d131b880-018b-11ea-80c7-46e66457d11e.png)

It will appear just in the mobile version.