### PR TITLE
Fixes youtube links for LH #10 and #11

### DIFF
--- a/src/_posts/2020-05-09-lh.md
+++ b/src/_posts/2020-05-09-lh.md
@@ -10,7 +10,7 @@ Pong: o famoso simulador de tênis de mesa lançado nos anos 70. Nessa LH, Mateu
 
 Essa LH foi gravada! Você pode vê-la no vídeo abaixo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=jJ9FDaXOoVo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/jJ9FDaXOoVo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <hr>
 

--- a/src/_posts/2020-05-23-lh.md
+++ b/src/_posts/2020-05-23-lh.md
@@ -11,7 +11,7 @@ Esse dia, P2 soltou a pérola "já tentou usar uma barata pra matar um canhão?"
 
 Essa LH foi gravada! Você pode vê-la no vídeo abaixo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/watch?v=CMNAlp-6bP8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/CMNAlp-6bP8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <hr>
 


### PR DESCRIPTION
Pretty self explanatory. The current link [does not work](https://lh.imesec.ime.usp.br/log/20/05/23) because youtube sets `X-Frame-Options` to `sameorigin` on `/watch`, so that it doesn't get clickjacked. We must use `/embed/:id` instead.

![image](https://user-images.githubusercontent.com/7110169/82897530-a5232c80-9f4f-11ea-972f-609019b890d1.png)
