### PR TITLE
Remove `sudo` as a dependency for the API

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,7 +1,5 @@
 FROM python:3.7
 
-RUN apt-get update && apt-get install -y sudo
-
 RUN python -m ensurepip
 RUN pip install pipenv
 


### PR DESCRIPTION
We never use it, yo.