### PR TITLE
Add new videos to posts and improve layout

### DIFF
--- a/src/_includes/post-video.html
+++ b/src/_includes/post-video.html
@@ -1,0 +1,9 @@
+<div class="post--video-container">
+  <iframe
+    class="post--video-iframe"
+    src="{{include.url}}"
+    frameborder="0"
+    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+  ></iframe>
+</div>

--- a/src/_posts/2019-08-21-lh.md
+++ b/src/_posts/2019-08-21-lh.md
@@ -25,6 +25,8 @@ Foi apresentado como é possível captar com um rádio as ondas eletromagnética
 ## 3. Bitshift variations in c minor
 > Hacker: Daniel Martinez
 
+{% include post-video.html url="https://www.youtube.com/embed/rEmy270w0fQ" %}
+
 Foi apresentado uma breve explicação do projeto [bitshift variations in c minor](https://github.com/JamesNewton/BitShift-Variations-unrolled), que usa um código de 214 bytes em C para produzir música. Algumas de suas características são usar operções em bits para manipular as ondas e o overflow das variáveis para criar as repetições.
 
 ## 4. Subversão da ordem: algoritmos de ordenação aplicados à arte

--- a/src/_posts/2019-09-11-lh.md
+++ b/src/_posts/2019-09-11-lh.md
@@ -31,6 +31,8 @@ uma linguagem que [não é regular](https://en.wikipedia.org/wiki/Regular_langua
 ## 3. Algorave
 > Hackers: Rafael Tsuha + Daniela Favero
 
+{% include post-video.html url="https://www.youtube.com/embed/3G4_vd7qRrk" %}
+
 [Algorave](https://github.com/Algorave/guidelines/blob/master/README_en.md) é um evento no qual as pessoas dançam ao som de 
 músicas geradas por algoritmos, utilizando técnicas de live coding. Nessa LH, Rafael Tsuha e Daniela Favero utilizaram três 
 ferramentas para criar uma música completamente do zero: [SuperCollider](https://supercollider.github.io/) (que gera o áudio), 

--- a/src/_posts/2019-09-18-lh.md
+++ b/src/_posts/2019-09-18-lh.md
@@ -15,12 +15,16 @@ Foi uma reunião extremamente dinâmica e intensa!
 ## 1. A beleza de códigos nojentos (feat. Union Find)
 > Hacker: Teos (Pedro Sousa)
 
+{% include post-video.html url="https://www.youtube.com/embed/4KG3-FAL2mg" %}
+
 Teos falou sobre a estrutura Union Find, introduzindo as eurísticas de path compression e union by weight.
 Uma rápida implementação no final da apresentação ajudou a acrescentar uma camada adicional aos códigos
 da maratona: eles não são apenas feios, são bonitos também!
 
 ## 2. Se sentindo como Von Neumann: brincando com somatórios como um computeiro
 > Hacker: Bento Pereira
+
+{% include post-video.html url="https://www.youtube.com/embed/h0-Xmnji3Hs" %}
 
 Anos atrás, em tempos imemoriais, o matemático John Von Neumann foi apresentado com um problema 
 [sobre uma pobre abelha](https://courses.cs.vt.edu/~cs1104/ProblemSolving/Trains/Train.html). 
@@ -31,6 +35,8 @@ segundos usando algo natural para computeiros: os números binários.
 ## 3. Uma Perspectiva geométrica à acordes
 > Hacker: P2 (Pedro Pereira)
 
+{% include post-video.html url="https://www.youtube.com/embed/fQq6d5kmGOE" %}
+
 Foi apresentada uma aplicação super simples: <https://chromatic.razgrizone.now.sh/>.
 Com ela, Pedro mostrou o que é uma escala e um acorde através de um polígono em um círculo das 12 notas.
 Conclusões incríveis foram tiradas: um acorde está dentro de uma escala se as diagonais que o acorde forma
@@ -40,6 +46,8 @@ O código fonte da aplicação [pode ser encontrado aqui.](https://github.com/pe
 
 ## 4. Funtores e Applicatives em Haskell
 > Hacker: spoonm
+
+{% include post-video.html url="https://www.youtube.com/embed/hgmQy5sBzV4" %}
 
 Uma tentativa de explicar em 5 minutos dois padrões recorrentes em programação funcional que foram 
 tirados de Teoria de Categorias: funtores e applicatives (funtores monoidais que preservam força tensorial), 

--- a/src/_posts/2019-09-25-lh.md
+++ b/src/_posts/2019-09-25-lh.md
@@ -26,11 +26,15 @@ https://docs.google.com/presentation/d/1iRhhZL8kFnk7Ndf6FkIdvzVbgesyGKz_VVSkazRy
 ## 2. Faça sua glitch art: databending com Audacity
 > Hacker: Daniela Favero
 
+{% include post-video.html url="https://www.youtube.com/embed/vL7HYr9CJxQ" %}
+
 Você conhece a estética de _glitch art_, na qual são exploradas várias formas de quebrar mídias para deixá-las estilizadas? Uma das formas de fazer glitch art é com _databending_, que é basicamente editar determinadas mídias em programas que esperam um outro tipo de mídia. Nessa Lightning Hack, a Dani ensinou a usar o [Audacity](https://www.audacityteam.org/) (um programa de edição de áudio) para gerar efeitos inusitados em imagens. Consulte as referências no [The Washington Post](https://www.washingtonpost.com/news/innovations/wp/2014/07/23/what-paris-looks-like-with-an-echo/) e no [glitchet](https://www.glitchet.com/).
 
 
 ## 3. Divisão usando uma calculadora mecânica
 > Hacker: P2 (Pedro Pereira)
+
+{% include post-video.html url="https://www.youtube.com/embed/bTTIgbBpf2s" %}
 
 Seja bem-vindo a uma [Curta](https://pt.wikipedia.org/wiki/Curta): uma calculadora mecânica de
 bolso! Ela consegue somar, subtrair, e multiplicar (através de somas repetidas). Entretanto,
@@ -39,6 +43,8 @@ Nessa Lightning Hack, P2 ensinou como dividir dois números em uma calculadora d
 
 ## 4. Chaotic Good: Desenhando Fractais com o jogo do caos
 > Hacker: Rafael Tsuha
+
+{% include post-video.html url="https://www.youtube.com/embed/NLrJ4kyJtSs" %}
 
 O jogo do caos é um processo iterativo que parte de um polígono e um ponto inicial e resulta num padrão fractal. Nessa apresentação exploramos algumas propriedades que podem ser modificadas para criar novos padrões.
 Referências:
@@ -49,5 +55,7 @@ https://gitlab.com/imaginative/chaosgame
 
 ## 5. Programando em templates de C++ feat. Fibonacci
 > Hacker: Mateus Barbosa
+
+{% include post-video.html url="https://www.youtube.com/embed/RG3n-msYz7E" %}
 
 Foram mostradas duas formas de calcular um termo da [sequência de Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_number) usando [templates](https://en.cppreference.com/w/cpp/language/templates) de C++: a primeira com uma fórmula recursiva usual e [especialização de templates](https://en.cppreference.com/w/cpp/language/template_specialization) para os casos base, e a segunda com uma [expressão lambda](https://en.cppreference.com/w/cpp/language/lambda) iterativa, [computável em tempo de compilação](https://en.cppreference.com/w/cpp/language/constexpr).

--- a/src/_posts/2019-10-16-lh.md
+++ b/src/_posts/2019-10-16-lh.md
@@ -16,6 +16,8 @@ reapresentação de hacks e o jedi retornou ao palco.
 ## 1. Programando em LaTeX (feat. Star Wars)
 > Hacker: Andrew Ijano
 
+{% include post-video.html url="https://www.youtube.com/embed/1M25NkU98As" %}
+
 O [LaTeX](https://www.latex-project.org/) é um sistema super famoso para
 criação de documentos de texto, principalmente acadêmicos. 
 
@@ -27,6 +29,8 @@ O código da apresentação pode ser encontrado em: [https://github.com/AndrewIj
 
 ## 2. Type checker em Python
 > Hacker: P2 (Pedro Pereira)
+
+{% include post-video.html url="https://www.youtube.com/embed/Irbmjzy49Aw" %}
 
 Nessa LH, P2 se aventurou em uma extravaganza de decorators em Python, que são apenas funções que 
 recebem funções e devolvem outras funções. Simples, não? O melhor é que o type checker pode 

--- a/src/_posts/2019-10-16-lh.md
+++ b/src/_posts/2019-10-16-lh.md
@@ -25,7 +25,7 @@ Nessa Lightning Hacks, Andrew mostrou que é possível programar em LaTeX
 usando [variáveis](https://www.texdev.net/2009/11/17/tex-counts-and-latex-counters/),
 [laços](https://texfaq.org/FAQ-repeat-num) e [macros](https://en.wikibooks.org/wiki/LaTeX/Macros). E ainda, foi mostrado como criar a [cena de abertura de Star Wars](https://en.wikipedia.org/wiki/Star_Wars_opening_crawl) usando LaTeX.
 
-O código da apresentação pode ser encontrado em: [https://github.com/AndrewIjano/latex-wars](https://github.com/AndrewIjano/latex-wars).
+O código da apresentação pode ser encontrado [aqui](https://github.com/AndrewIjano/latex-wars).
 
 ## 2. Type checker em Python
 > Hacker: P2 (Pedro Pereira)

--- a/src/_posts/2019-10-30-lh.md
+++ b/src/_posts/2019-10-30-lh.md
@@ -16,12 +16,16 @@ meio do chat, mas não disfarçados de Andrew. Uma das primeiras mensagens que o
 ## 1. Como esconder seu robô com cadeias de Markov
 > Hacker: Andrew Ijano
 
+{% include post-video.html url="https://www.youtube.com/embed/Ef0zTaZx548" %}
+
 Já pensou em escrever mensagens automáticas que se parecem com mensagens reais? Nesse dia, Andrew mostrou como usar cadeias de Markov e a API do Telegram para isso. Usando a API, é possível ler mensagens de vários grupos, armazenar o padrão de escrita das pessoas e gerar uma menagens nova a partir desse novo padrão.
 
 O código da apresentação pode ser encontrado em: [https://github.com/AndrewIjano/doppelganger-bot](https://github.com/AndrewIjano/doppelganger-bot).
 
 ## 2. Como transferir arquivos sem pendrive
 > Hacker: P2 (Pedro Pereira)
+
+{% include post-video.html url="https://www.youtube.com/embed/_jUcT526fBo" %}
 
 P2 apresentou uma das ferramentas a se ter no canivete suiço de tode computeire: criar servidores
 HTTP em uma pasta para compartilhar arquivos em uma rede local. Basta rodar `python3 -m http.server`
@@ -31,10 +35,14 @@ na pasta que você quer compartilhar! O outro computador pode acessar o seu IP n
 ## 3. Trocando a senha de root do amiguinho em 30s
 > Hacker: Daniel Martinez
 
+{% include post-video.html url="https://www.youtube.com/embed/GrnzdrzegM0" %}
+
 `init=/bin/bash`. Isso é tudo que você precisa adicionar na linha de comando do kernel pra logar como root no computador do seu amiguinho, desde que o HD dele não esteja criptografado, claro! 
 
 
 ## 4. [Ao vivo] Uma apresentação do Tsu
 > Hacker: Rafael Tsuha
+
+{% include post-video.html url="https://www.youtube.com/embed/2zLV4AjiPV8" %}
 
 *Apresentação sem descrição*

--- a/src/_posts/2019-10-30-lh.md
+++ b/src/_posts/2019-10-30-lh.md
@@ -20,7 +20,7 @@ meio do chat, mas não disfarçados de Andrew. Uma das primeiras mensagens que o
 
 Já pensou em escrever mensagens automáticas que se parecem com mensagens reais? Nesse dia, Andrew mostrou como usar cadeias de Markov e a API do Telegram para isso. Usando a API, é possível ler mensagens de vários grupos, armazenar o padrão de escrita das pessoas e gerar uma menagens nova a partir desse novo padrão.
 
-O código da apresentação pode ser encontrado em: [https://github.com/AndrewIjano/doppelganger-bot](https://github.com/AndrewIjano/doppelganger-bot).
+O código da apresentação pode ser encontrado [aqui](https://github.com/AndrewIjano/doppelganger-bot).
 
 ## 2. Como transferir arquivos sem pendrive
 > Hacker: P2 (Pedro Pereira)

--- a/src/_posts/2019-11-06-lh.md
+++ b/src/_posts/2019-11-06-lh.md
@@ -25,6 +25,8 @@ Os slides da apresentação estão em [https://docs.google.com/presentation/d/1p
 ## 2. Como ler um HUD de um avião militar
 > Hacker: P2 (Pedro Pereira)
 
+{% include post-video.html url="https://www.youtube.com/embed/qagDEClrKCM" %}
+
 P2 mostrou um [vídeo emocionante](https://youtu.be/WkZGL7RQBVw): Um piloto de caça sendo
 salvo pelo computador de bordo! Mesmo assim, o vídeo é muito confuso. P2 então
 explicou as informações principais que aparecem no display de bordo do vídeo, assim

--- a/src/_posts/2019-11-06-lh.md
+++ b/src/_posts/2019-11-06-lh.md
@@ -13,13 +13,13 @@ O P2 trouxe um avião de brinquedo. ✈️
 ## 1. Como automatizar seus estudos
 > Hacker: Andrew Ijano
 
-Uma das questões de uma prova de proficiência em inglês é o [multiple choice cloze](https://www.esl-lounge.com/student/first-certificate-multiple-choice-cloze.php). Nela, há uma frase com uma palavra faltando e uma lista de plavras semelhantes que poderiam substituí-la. Normalmente, essas palavras são conjunções e preposições, assim, é certo que só há uma resposta correta.
+Uma das questões de uma prova de proficiência em inglês é o [multiple choice cloze](https://www.esl-lounge.com/student/first-certificate-multiple-choice-cloze.php). Nela, há uma frase com uma palavra faltando e uma lista de palavras semelhantes que poderiam substituí-la. Normalmente, essas palavras são conjunções e preposições, assim, é certo que só há uma resposta correta.
 
 Para isso, Andrew mostrou como criar um _script_ que cria automaticamente questões desse tipo.
 
 O código da apresentação pode ser encontrado em [https://github.com/AndrewIjano/multiple-choice-cloze-generator](https://github.com/AndrewIjano/multiple-choice-cloze-generator).
 
-Os slides da apresentação estão em [https://docs.google.com/presentation/d/1p8OwhiTgv7HLK71YEKy7EKXZhqAGVWLB6F7onQBuKqs/edit?usp=sharing](https://docs.google.com/presentation/d/1p8OwhiTgv7HLK71YEKy7EKXZhqAGVWLB6F7onQBuKqs/edit?usp=sharing).
+Os slides da apresentação podem ser encontrados [aqui](https://docs.google.com/presentation/d/1p8OwhiTgv7HLK71YEKy7EKXZhqAGVWLB6F7onQBuKqs/edit?usp=sharing).
 
 
 ## 2. Como ler um HUD de um avião militar

--- a/src/_posts/2020-04-11-lh.md
+++ b/src/_posts/2020-04-11-lh.md
@@ -14,7 +14,7 @@ trabalhar de casa. Depois de umas 3 semanas de distanciamento social,
 
 Essa LH foi gravada! Você pode encontrar o vídeo abaixo.
 
-{% include post-video.html url="https://www.youtube.com/embed/Hksu-zRh5_Q" %}
+{% include post-video.html url="https://www.youtube.com/embed/AquIr662Zz8" %}
 
 <hr>
 

--- a/src/_posts/2020-04-11-lh.md
+++ b/src/_posts/2020-04-11-lh.md
@@ -14,7 +14,7 @@ trabalhar de casa. Depois de umas 3 semanas de distanciamento social,
 
 Essa LH foi gravada! Você pode encontrar o vídeo abaixo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Hksu-zRh5_Q" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{% include post-video.html url="https://www.youtube.com/embed/Hksu-zRh5_Q" %}
 
 <hr>
 

--- a/src/_posts/2020-05-09-lh.md
+++ b/src/_posts/2020-05-09-lh.md
@@ -10,7 +10,7 @@ Pong: o famoso simulador de tênis de mesa lançado nos anos 70. Nessa LH, Mateu
 
 Essa LH foi gravada! Você pode vê-la no vídeo abaixo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/jJ9FDaXOoVo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{% include post-video.html url="https://www.youtube.com/embed/jJ9FDaXOoVo" %}
 
 <hr>
 

--- a/src/_posts/2020-05-23-lh.md
+++ b/src/_posts/2020-05-23-lh.md
@@ -11,7 +11,7 @@ Esse dia, P2 soltou a pérola "já tentou usar uma barata pra matar um canhão?"
 
 Essa LH foi gravada! Você pode vê-la no vídeo abaixo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/CMNAlp-6bP8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{% include post-video.html url="https://www.youtube.com/embed/CMNAlp-6bP8" %}
 
 <hr>
 

--- a/src/_posts/2020-06-13-lh.md
+++ b/src/_posts/2020-06-13-lh.md
@@ -10,7 +10,7 @@ Três das quatro apresentações dessa semana envolveram música. Essa foi a LH 
 
 Essa LH foi gravada! Você pode vê-la no vídeo abaixo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/9PghNZV28cw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{% include post-video.html url="https://www.youtube.com/embed/9PghNZV28cw" %}
 
 <hr>
 

--- a/src/_sass/post.scss
+++ b/src/_sass/post.scss
@@ -32,3 +32,18 @@
         padding-bottom: 2em;
     }
 }
+
+.post--video-container {
+        position: relative;
+        overflow: hidden;
+        padding-top: 56.25%;
+}
+  
+.post--video-iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+}

--- a/src/_sass/post.scss
+++ b/src/_sass/post.scss
@@ -23,7 +23,7 @@
 
     // Since posts are in markdown, unfortunately we need to target tags and not classes
     h2 {
-        padding-top: 1.5em;
+        padding-top: 2.5em;
     }
 
     hr {
@@ -38,9 +38,13 @@
         color: $pink-lh;
     }
 
+    p {
+        margin-bottom: 0.5em;
+    }
+
     blockquote {
         color: $light-gray-lh;
-        padding-bottom: 2em;
+        padding-bottom: 1.5em;
     }
 }
 

--- a/src/_sass/post.scss
+++ b/src/_sass/post.scss
@@ -2,6 +2,10 @@
     background-color: $near-white-lh;
     padding-bottom: 2em;
     padding-top: 2em;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 
@@ -11,9 +15,12 @@
 
 .post--content {
     position: relative;
-    left: 15vw;
-    max-width: 70vw;
+    // Reduce the text width to improve reading on large screens 
+    max-width: 680px;
+    margin: 64px;
+
     padding-bottom: 2em;
+
     // Since posts are in markdown, unfortunately we need to target tags and not classes
     h2 {
         padding-top: 1.5em;
@@ -37,6 +44,7 @@
         position: relative;
         overflow: hidden;
         padding-top: 56.25%;
+        margin-bottom: 1.5em;
 }
   
 .post--video-iframe {

--- a/src/_sass/post.scss
+++ b/src/_sass/post.scss
@@ -34,6 +34,10 @@
         border-color: $near-white-lh;
     }
 
+    a {
+        color: $pink-lh;
+    }
+
     blockquote {
         color: $light-gray-lh;
         padding-bottom: 2em;


### PR DESCRIPTION
# Problems
The posts of Lightning Hacks have three main problems:

## Videos in posts aren't responsive
![image](https://user-images.githubusercontent.com/37511135/97116028-5681e600-16d9-11eb-9cf3-0cd5dbc9e900.png)

## Most videos of past LHs on YouTube aren't linked on posts
YouTube:
![image](https://user-images.githubusercontent.com/37511135/97116130-d740e200-16d9-11eb-83b0-47588c95dd1e.png)

Post of this LH:
![image](https://user-images.githubusercontent.com/37511135/97116142-ec1d7580-16d9-11eb-8164-e59eab7b6374.png)

## Posts are difficult to read on large screens because they are too wide
![image](https://user-images.githubusercontent.com/37511135/97116169-30a91100-16da-11eb-8714-923331539a0a.png)

# Solutions
## Reponsive videos
Videos now are responsive and can be embedded with a new component.
![image](https://user-images.githubusercontent.com/37511135/97116230-9e553d00-16da-11eb-9062-b72be6cddc4d.png)

## New embedded videos
Now every recorded LH has its embedded video on posts.
![image](https://user-images.githubusercontent.com/37511135/97116280-dd838e00-16da-11eb-8214-226fdc9159c1.png)

## Small width for large screens
Posts have now fixed width for large screens. 
![image](https://user-images.githubusercontent.com/37511135/97116303-f724d580-16da-11eb-9666-705a0b484b31.png)

## Other small fixes
- Explicit links that break mobile visualization
- Wrong YouTube links for videos (using IMEsec's YouTube instead of LH's)
- Now links are pink!
![image](https://user-images.githubusercontent.com/37511135/97116385-74e8e100-16db-11eb-83e7-819aede00ef3.png)
